### PR TITLE
Add comments deleted by YCP Killer

### DIFF
--- a/src/modules/Ldap.rb
+++ b/src/modules/Ldap.rb
@@ -304,7 +304,11 @@ module Yast
       @sssd_enumerate = false
 
       @ldap_error_hints = {
-        -1  => _("Verify that the LDAP Server is running and reachable."),
+        # hint to error message
+        -1  => _(
+          "Verify that the LDAP Server is running and reachable."
+        ),
+        # hint to error message
         -11 => _(
           "Failed to establish TLS encryption.\nVerify that the correct CA Certificate is installed and the Server Certificate is valid."
         ),


### PR DESCRIPTION
When this module was translated from YCP to Ruby using YCP Killer, two
comments were lost because of a bug in yast2-core. This bug has since
been fixed (in yast2-core 3.0.1). After the fix I re-translated this
module using fixed yast2-core and made a diff against the original
translation result. This commit applies this diff, restoring the lost
comments.

See https://github.com/yast/ycp-killer/issues/617.
