### PR TITLE
- remove krb5 realm and kdc from sssd config when Kerberos support

### DIFF
--- a/package/yast2-ldap-client.changes
+++ b/package/yast2-ldap-client.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Dec  5 16:44:42 CET 2013 - jsuchome@suse.cz
+
+- remove krb5 realm and kdc from sssd config when Kerberos support
+  is switched off (bnc#853331)
+
+-------------------------------------------------------------------
 Fri Nov 22 13:26:14 CET 2013 - jsuchome@suse.cz
 
 - do not change nscd cache value for OES (bnc#848051)

--- a/src/include/ldap/ui.rb
+++ b/src/include/ldap/ui.rb
@@ -1382,6 +1382,7 @@ module Yast
               Ldap.nss_base_passwd != nss_base_passwd ||
               Ldap.nss_base_group != nss_base_group ||
               Ldap.nss_base_automount != nss_base_automount ||
+              Ldap.sssd_with_krb != sssd_with_krb ||
               Ldap.krb5_realm != krb5_realm ||
               Ldap.krb5_server != krb5_server ||
               Ldap.sssd_cache_credentials != sssd_cache_credentials ||

--- a/src/modules/Ldap.rb
+++ b/src/modules/Ldap.rb
@@ -2414,6 +2414,8 @@ module Yast
       else
         SCR.Write(Builtins.add(domain, "chpass_provider"), "ldap")
         SCR.Write(Builtins.add(domain, "auth_provider"), "ldap")
+        SCR.Write(Builtins.add(domain, "krb5_realm"), nil)
+        SCR.Write(Builtins.add(domain, "krb5_server"), nil)
       end
 
       if !SCR.Write(path(".etc.sssd_conf"), nil)


### PR DESCRIPTION
  is switched off (bnc#853331)
